### PR TITLE
import APIException to prevent APIException is not defined

### DIFF
--- a/pagarmecoreapi/controllers/base_controller.py
+++ b/pagarmecoreapi/controllers/base_controller.py
@@ -9,6 +9,7 @@
 from pagarmecoreapi.api_helper import APIHelper
 from pagarmecoreapi.http.http_context import HttpContext
 from pagarmecoreapi.http.requests_client import RequestsClient
+from pagarmecoreapi.exceptions.api_exception import APIException
 from pagarmecoreapi.exceptions.error_exception import ErrorException
 
 class BaseController(object):


### PR DESCRIPTION
I'm trying to use paymecoreapi and I ended up getting an API error:
```
  File "pagarmecoreapi/controllers/base_controller.py", line 106, in validate_response
              raise APIException('HTTP response not OK.', context)
NameError: name 'APIException' is not defined
```
I believe this solution will solve my problem and someone else's if they suffer from the same problem.