### PR TITLE
Fixing unimported exception

### DIFF
--- a/pagarmecoreapi/controllers/base_controller.py
+++ b/pagarmecoreapi/controllers/base_controller.py
@@ -103,4 +103,4 @@ class BaseController(object):
         elif context.response.status_code == 500:
             raise ErrorException('Internal server error', context)
         elif (context.response.status_code < 200) or (context.response.status_code > 208): #[200,208] = HTTP OK
-            raise APIException('HTTP response not OK.', context)
+            raise ErrorException('HTTP response not OK.', context)


### PR DESCRIPTION
### Task [PAOMNI-61](https://mundipagg.atlassian.net/browse/PAOMNI-61)

### Changes of this PR
- [x] ✨ Bugfix


### Status

READY

### Whats?

We found that APIMATIC generated a bug in the python SDK "pay-core-api-python" which at the time it occurs
any error < 200 or > 208 that is not mapped it returns an exception that was not imported.

<img width="621" alt="Screenshot_11" src="https://user-images.githubusercontent.com/42675117/182458815-00b84e07-fe5d-449f-98d4-cfd18df5fa2f.png">

### Tests
- Simulating customer error
<img width="932" alt="Screenshot_9" src="https://user-images.githubusercontent.com/42675117/182456571-85bea6ef-ae53-4aaa-a19d-8d4db8a2be26.png">

- Returning correct error
<img width="937" alt="Screenshot_10" src="https://user-images.githubusercontent.com/42675117/182456602-4d04ffe3-4bc7-4920-b414-babbc1d82954.png">


![Git Merge](http://pa1.narvii.com/6471/69326493f70a8371c8cba9e63bdc21cee3c6db54_00.gif)
